### PR TITLE
Fix first countdown being cut off when viewport is too short

### DIFF
--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -96,8 +96,8 @@
 
 </script>
 
-<div class="flex flex-col md:justify-center items-center h-[100vh] max-h-[100vh] w-[100vw] overflow-x-hidden">
-  <div class="flex-grow flex flex-col gap-12 md:justify-center items-center py-8 w-[100vw] dark:text-zinc-50">
+<div class="flex flex-col md:justify-center items-center min-h-[100vh] w-full overflow-x-hidden">
+  <div class="flex-grow flex flex-col gap-12 md:justify-center items-center py-8 w-full dark:text-zinc-50">
    {#each $dates as date (date.id)}
       <div
         class="bg-zinc-200 dark:bg-zinc-800 rounded-lg px-4 md:px-8 pt-8 pb-4"


### PR DESCRIPTION
Before:
![first countdown is cut off, cannot scroll to see it](https://user-images.githubusercontent.com/6181929/177024709-e4cd3586-2524-4772-bf68-522b45d9e507.png)

After:
![first countdown is displayed in full](https://user-images.githubusercontent.com/6181929/177025277-fa580db9-39c3-44c5-bb7c-82dd171925fb.png)

Notice the page is scrolled all the way to the top in both images.

Screenshots taken in Chrome 103.0.5060.66, but this was also replicated in Firefox DE 103.0b3.
window.innerWidth = 1304; window.innerHeight = 669; and dates.length = 3