### PR TITLE
feat: Close copy menu after copying item

### DIFF
--- a/src/routes/_dropdown.svelte
+++ b/src/routes/_dropdown.svelte
@@ -77,6 +77,7 @@
       tabindex="-1"
       in:scale={{ duration: 100, start: 0.95 }}
       out:scale={{ duration: 75, start: 0.95 }}
+      on:click={() => { setTimeout(() => isOpen = !isOpen, 500) }}
     >
       <slot name="items" />
     </div>


### PR DESCRIPTION
Leaving the menu open after a copy has occurred seems clunky, since the user is likely clicking away to paste the copied text elsewhere.