### PR TITLE
feat: Add date grouping to avoid showing too many things at once

### DIFF
--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -2,6 +2,8 @@ export type CountdownDate = {
   id: number,
   date: string,
   title: string,
-  description: string
+  description: string,
+  group?: string,
+  priority: number,
 }
 

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -3,7 +3,7 @@
   import Timer from "./_timer.svelte";
   import CopyTimeDropdown from "./_copy_time_dropdown.svelte";
   import { onMount, onDestroy } from "svelte";
-  import { addSeconds, compareAsc, format, formatISO, min, parseISO } from "date-fns";
+  import { addSeconds, closestIndexTo, compareAsc, format, formatISO, min, parseISO } from "date-fns";
   import { browser } from "$app/env";
 
   import { fade } from "svelte/transition";
@@ -39,6 +39,14 @@
       $dates = $dates.filter(
         (d) => compareAsc(now, parseISO(d.date)) < 0
       );
+      $dates = $dates.filter(
+        (d) => {
+          if (d.group === null) return true;
+          const datesInGroup = $dates.filter((d2) => d2.group === d.group);
+          const minDateInGroup = datesInGroup[0];
+          return d.date === minDateInGroup.date;
+        }
+      );
     } catch (error) {
       hadError = true;
       console.error(error);
@@ -69,6 +77,7 @@
         date: formatISO(addSeconds(now, backoff + 1)),
         title: hadError ? "Error getting countdown data, retrying in..." : "No countdown found, refreshing in...",
         description: "",
+        priority: 100
       }];
       backoff = clamp(backoff + getAdditionalBackoffAmount(backoff) + Math.random() * 0.5, 15, 59);
     } else {

--- a/src/stores/dates.ts
+++ b/src/stores/dates.ts
@@ -1,28 +1,41 @@
 import client from "$lib/db";
 
 import type { CountdownDate } from "$lib/types";
-import { addSeconds, addMinutes, addHours, addDays, formatISO } from "date-fns";
+// import { addSeconds, addMinutes, addHours, addDays, formatISO, parseISO } from "date-fns";
 import { writable } from "svelte/store";
 
 const tableName = "Upcoming Dates";
-const select = `id, title, description, date`;
+const select = `id, title, description, date, group`;
 
 export const dates = writable([] as CountdownDate[]);
 export const DATES_PAGE_SIZE = 10;
 
 export async function getDates(page = 0): Promise<CountdownDate[]> {
+  // const timeInTheFuture = "2022-10-06T17:57:00-07:00";
   // return [
   //   {
   //     id: 1,
   //     title: "The End of the World",
   //     description: "The end of the world is coming",
-  //     date: "2022-06-08T17:10:00-07:00",
+  //     date: timeInTheFuture,
+  //     priority: 0,
+  //     group: "ohno",
   //   },
   //   {
   //     id: 2,
   //     title: "The End of the World 2",
   //     description: "The end of the world is coming again",
-  //     date: formatISO(addSeconds(addDays(new Date(), 1), 17)),
+  //     date: formatISO(addSeconds(addDays(parseISO(timeInTheFuture), 1), 17)),
+  //     priority: 0,
+  //     group: "ohno",
+  //   },
+  //   {
+  //     id: 3,
+  //     title: "A new element",
+  //     description: "asdf",
+  //     date: formatISO(addSeconds(addDays(parseISO(timeInTheFuture), 1), 17)),
+  //     priority: 0,
+  //     group: null
   //   }
   // ]
   const { data, error } = await client.from(tableName)


### PR DESCRIPTION
This PR adds date grouping, which hides dates further into the future which are reliant on more imminent dates.

For example, it does not make sense to show when a multi-day event ends until the event has started. Therefore, the start and end dates would be grouped, and the end date would only be shown after the start date arrives.
