### PR TITLE
fix: Properly localize time for edit form

### DIFF
--- a/src/lib/components/event/_form.svelte
+++ b/src/lib/components/event/_form.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { CountdownDate } from "$lib/types";
+  import { parseISO, format } from "date-fns";
 
   export let event: CountdownDate | undefined = undefined;
 
@@ -17,8 +18,8 @@
     title = event.title;
     description = event.description;
     group = event.group;
-    if (event.date) date = event.date.slice(0, 19); // Remove timezone information
-    if (event.end_date) end_date = event.end_date.slice(0, 19); // Remove timezone information
+    if (event.date) date = format(parseISO(event.date), "yyyy-LL-dd'T'HH:mm:ss"); // Localize datetime
+    if (event.end_date) end_date = format(parseISO(event.end_date), "yyyy-LL-dd'T'HH:mm:ss").slice(0, 19); // Localize datetime
     priority = event?.priority || 0;
   }
 </script>


### PR DESCRIPTION
This PR addresses a bug which caused datetimes to load incorrectly in the event edit form
