### PR TITLE
fix: Show events which are occurring now

### DIFF
--- a/src/lib/components/_copy_time_dropdown.svelte
+++ b/src/lib/components/_copy_time_dropdown.svelte
@@ -7,16 +7,16 @@
   import type { CountdownDate } from "$lib/types";
   import { format, parseISO } from "date-fns";
 
-  export let date : CountdownDate;
+  export let event : CountdownDate;
 
-  const dateObj = parseISO(date.date);
+  const dateObj = parseISO(event.date);
 
   async function copyDiscordTimestamp() {
     await navigator.clipboard.writeText(`<t:${Math.floor(dateObj.getTime() / 1000)}:f> (<t:${Math.floor(dateObj.getTime() / 1000)}:R>)`);
   }
 
   async function copyNormalTimestamp() {
-    await navigator.clipboard.writeText(format(parseISO(date.date), "PPPPp"))
+    await navigator.clipboard.writeText(format(parseISO(event.date), "PPPPp"))
   }
 </script>
 

--- a/src/lib/utils/event_helpers.ts
+++ b/src/lib/utils/event_helpers.ts
@@ -1,6 +1,17 @@
+import type { CountdownDate } from "$lib/types";
+import { parseISO } from "date-fns";
+
 export function titleToSlug(title: string) {
   return title.toLowerCase()
     .replace(/\[.*?\]/g, "")       // REMOVE STATUS MESSAGES
     .replace(/[^a-z0-9 ]/g, "")
     .replace(/ +/g, "-");
+}
+
+export function isEventHappeningNow(event: CountdownDate, now?: Date) {
+  if (now == undefined) now = new Date();
+
+  return event && event.date && event.end_date
+    && parseISO(event.date) < now
+    && parseISO(event.end_date) > now;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -84,9 +84,9 @@
 {/if}
 <div class="flex-grow flex flex-col gap-8 md:justify-center items-center md:mx-4 my-8 w-full dark:text-zinc-50">
   {#if displayDates?.length != undefined && displayDates.length > 0}
-    {#each displayDates as date (date.id)}
+    {#each displayDates as event (event.id)}
       <div animate:flip>
-        <EventCard {now} {date} />
+        <EventCard {now} {event} />
       </div>
     {/each}
   {:else if loading}

--- a/src/routes/_event_card.svelte
+++ b/src/routes/_event_card.svelte
@@ -13,7 +13,7 @@
   import Timer from "$lib/components/_timer.svelte";
   import { titleToSlug } from "$lib/utils/event_helpers";
 
-  export let date: CountdownDate;
+  export let event: CountdownDate;
   export let now: Date;
 </script>
 
@@ -24,28 +24,28 @@
   <p
     class="text-center text-xl md:text-2xl lg:text-3xl whitespace-pre-line"
     in:fade="{{duration: 500, delay: 200}}">
-    <a href={`/event/${date.id}/${titleToSlug(date.title)}`} class="text-ow2-orange dark:text-ow2-light-orange hover:underline focus:underline">{date.title}</a>
-    {#if date.id !== -1}
+    <a href={`/event/${event.id}/${titleToSlug(event.title)}`} class="text-ow2-orange dark:text-ow2-light-orange hover:underline focus:underline">{event.title}</a>
+    {#if event.id !== -1}
       <a
         class="inline sm:absolute sm:right-0 sm:top-0 sm:mr-4 sm:mt-3 px-2 py-1 bg-zinc-500 hover:bg-zinc-400 dark:bg-zinc-700 dark:hover:bg-zinc-600 text-zinc-200 rounded-md text-lg transition-colors"
-        href={`/event/${date.id}/${titleToSlug(date.title)}`}
+        href={`/event/${event.id}/${titleToSlug(event.title)}`}
       >
         <FontAwesomeIcon icon={faCircleInfo} />
-        <span class="screenreader-only">{date.title + " Information"}</span>
+        <span class="screenreader-only">{event.title + " Information"}</span>
       </a>
     {/if}
   </p>
-  {#if date.id !== -1 && date.date !== null}
+  {#if event.id !== -1 && displayDate !== null}
     <p
       class="text-center text-lg md:text-xl lg:text-2xl"
       in:fade="{{duration: 500, delay: 500}}">
-      <CopyTimeDropdown class="ml-1" date={date}>
-        <span slot="button-text"><time datetime={date.date}>{format(parseISO(date.date), "PPPPp")}</time></span>
+      <CopyTimeDropdown class="ml-1" event={event}>
+        <span slot="button-text"><time datetime={displayDate}>{format(parseISO(displayDate), "PPPPp")}</time></span>
       </CopyTimeDropdown>
     </p>
   {/if}
   <div class="flex justify-center">
-    <Timer start={now} end={parseISO(date.date)} id={date.id}/>
+    <Timer start={now} end={parseISO(event.date)} id={event.id}/>
   </div>
 </div>
 

--- a/src/routes/_event_card.svelte
+++ b/src/routes/_event_card.svelte
@@ -38,7 +38,10 @@
     {/if}
   </p>
   {#if event.id !== -1 && displayDate !== null}
-    <p class="text-center text-lg md:text-xl lg:text-2xl">
+    <p
+      class="text-center text-lg md:text-xl lg:text-2xl"
+      in:fade={{duration: 500, delay: 350}}
+    >
       Event {isEventHappeningNow(event, now) ? "ends" : "begins"} on
     </p>
     <p

--- a/src/routes/_event_card.svelte
+++ b/src/routes/_event_card.svelte
@@ -11,10 +11,12 @@
   import CopyTimeDropdown from "$lib/components/_copy_time_dropdown.svelte";
   import type { CountdownDate } from "$lib/types";
   import Timer from "$lib/components/_timer.svelte";
-  import { titleToSlug } from "$lib/utils/event_helpers";
+  import { isEventHappeningNow, titleToSlug } from "$lib/utils/event_helpers";
 
   export let event: CountdownDate;
   export let now: Date;
+
+  $: displayDate = (isEventHappeningNow(event, now) && event.end_date) ? event.end_date : event?.date;
 </script>
 
 <div
@@ -36,6 +38,9 @@
     {/if}
   </p>
   {#if event.id !== -1 && displayDate !== null}
+    <p class="text-center text-lg md:text-xl lg:text-2xl">
+      Event {isEventHappeningNow(event, now) ? "ends" : "begins"} on
+    </p>
     <p
       class="text-center text-lg md:text-xl lg:text-2xl"
       in:fade="{{duration: 500, delay: 500}}">
@@ -45,7 +50,7 @@
     </p>
   {/if}
   <div class="flex justify-center">
-    <Timer start={now} end={parseISO(event.date)} id={event.id}/>
+    <Timer start={now} end={parseISO(displayDate)} id={event.id}/>
   </div>
 </div>
 

--- a/src/routes/api/events/+server.ts
+++ b/src/routes/api/events/+server.ts
@@ -14,7 +14,7 @@ export const GET: RequestHandler = async ({ params, setHeaders }) => {
     .order("priority", {ascending: false})
     .order("date", {ascending: true})
 
-  if (!params["include_past"]) { query = query.or(`date.gte.${formatISO(new Date())},date.is.null`) }
+  if (!params["include_past"]) { query = query.or(`date.gte.${formatISO(new Date())},end_date.gte.${formatISO(new Date())},date.is.null`) }
 
   query = query.range(pageNum * DATES_PAGE_SIZE, ((pageNum + 1) * DATES_PAGE_SIZE) - 1);
 

--- a/src/routes/event/[id]/[slug]/+page.svelte
+++ b/src/routes/event/[id]/[slug]/+page.svelte
@@ -59,7 +59,7 @@ import { titleToSlug } from '$lib/utils/event_helpers';
   class="text-center text-lg md:text-xl lg:text-2xl"
   in:fade={{duration: 1000, delay: 500, easing: quintInOut}}>
   {#if event.date !== null}
-    <CopyTimeDropdown class="ml-1" date={event}>
+    <CopyTimeDropdown class="ml-1" event={event}>
       <span slot="button-text"><time datetime={event.date}>{format(parseISO(event.date), "PPPPp")}</time></span>
     </CopyTimeDropdown>
   {/if}


### PR DESCRIPTION
This PR fixes a bug with the OW2Countdown homepage where events whose start dates had elapsed, but whose end dates had not, would not appear.

In addition, this PR also temporarily adds text specifying whether a countdown's date is the start or end of an event. A more comprehensive approach is being worked on, but this will tide the site over until then.
