### PR TITLE
Page transition fixes

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -18,8 +18,8 @@
   });
 </script>
 
-<div class="wrapper min-h-[100vh] max-w-full overflow-x-hidden mx-2">
-  <main class="main__wrapper max-w-full mx-auto">
+<div class="wrapper min-h-screen max-w-full overflow-x-hidden mx-2">
+  <main class="main__wrapper max-w-full mx-auto relative">
     <slot />
   </main>
   <footer

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -23,7 +23,7 @@
     <slot />
   </main>
   <footer
-    class="flex justify-between gap-2 px-2 pt-4 mt-8 mb-2 w-full overflow-x-hidden overflow-y-visible border-t-[1px] border-t-zinc-400 dark:border-t-zinc-700"
+    class="flex justify-between gap-2 px-2 pt-4 mt-8 mb-2 w-full overflow-y-visible border-t-[1px] border-t-zinc-400 dark:border-t-zinc-700"
   >
     <p class="text-xs text-zinc-500 dark:text-zinc-400 italic text-left">Created by CactusPuppy<br /><a href="https://github.com/CactusPuppy/ow2countdown" rel="noreferrer noopener" target="_blank" class="text-ow2-orange dark:text-ow2-light-orange underline">GitHub</a></p>
     <p class="text-xs text-zinc-500 dark:text-zinc-400 italic text-right">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -82,19 +82,19 @@
   <div class="fixed top-0 left-0 z-30 w-full text-center p-4 bg-[#f15047df] dark:bg-[#7F1D1DDF] dark:text-zinc-50">
     A problem arose while contacting the server for updated information. Don't refresh, we'll try to contact the server again for you {nextAttemptMarker !== undefined && compareAsc(now, nextAttemptMarker) < 0 ? `in ${timeToNextAttempt}` : "soon"}.</div>
 {/if}
-<div class="flex-grow flex flex-col gap-8 md:justify-center items-center my-8 w-full dark:text-zinc-50">
+<div class="grid grid-cols-1 gap-8 self-start items-center my-8 w-full dark:text-zinc-50">
   {#if displayDates?.length != undefined && displayDates.length > 0}
     {#each displayDates as event, eventIndex (event.id)}
-      <div animate:flip>
+      <div class="justify-self-center" animate:flip>
         <EventCard {now} {event} additionalDelay={eventIndex * 150} />
       </div>
     {/each}
   {:else if loading}
-    <div class="text-center">
+    <div class="absolute top-1/2 -translate-x-1/2 -translate-y-1/2 text-center">
       <h1 class="text-5xl mb-4 text-ow2-orange dark:text-ow2-light-orange">Loading...</h1>
     </div>
   {:else}
-      <div class="text-center">
+      <div class="absolute top-1/2 -translate-x-1/2 -translate-y-1/2 w-max text-center">
         <h1 class="text-5xl mb-4 text-ow2-orange dark:text-ow2-light-orange">No events found</h1>
         <p class="text-xl">Next refresh {nextAttemptMarker !== undefined && compareAsc(now, nextAttemptMarker) < 0 ? `in ${timeToNextAttempt}` : "soon"}</p>
       </div>

--- a/src/routes/_event_card.svelte
+++ b/src/routes/_event_card.svelte
@@ -20,7 +20,8 @@
 
 <div
   class="bg-zinc-200 dark:bg-zinc-800 rounded-lg px-4 sm:px-12 pt-8 pb-4 relative w-min"
-  in:fade="{{delay: additionalDelay}}">
+  in:fade="{{delay: additionalDelay}}"
+  out:fade>
   <p
     class="text-center text-xl md:text-2xl lg:text-3xl whitespace-pre-line"
     in:fade="{{duration: 500, delay: 200 + additionalDelay}}"

--- a/src/routes/event/[id]/[slug]/+page.svelte
+++ b/src/routes/event/[id]/[slug]/+page.svelte
@@ -57,23 +57,25 @@
 >
   {event.title}
 </h1>
-<p
-  class="text-center text-lg md:text-xl lg:text-2xl"
-  in:fade={{duration: 1000, delay: 450, easing: quintInOut}}
-  out:fade
->
-  Event {isEventHappeningNow(event, now) ? "ends" : "begins"} on
-</p>
-<p
-  class="text-center text-lg md:text-xl lg:text-2xl"
-  in:fade={{duration: 1000, delay: 500, easing: quintInOut}}
-  out:fade={{easing: quintInOut}}>
-  {#if event.date !== null}
-    <CopyTimeDropdown class="ml-1" event={event}>
-      <span slot="button-text"><time datetime={dateStringToDisplay}>{format(parseISO(dateStringToDisplay), "PPPPp")}</time></span>
-    </CopyTimeDropdown>
-  {/if}
-</p>
+<div>
+  <p
+    class="text-center text-lg md:text-xl lg:text-2xl"
+    in:fade={{duration: 1000, delay: 450, easing: quintInOut}}
+    out:fade
+  >
+    Event {isEventHappeningNow(event, now) ? "ends" : "begins"} on
+  </p>
+  <p
+    class="text-center text-lg md:text-xl lg:text-2xl"
+    in:fade={{duration: 1000, delay: 500, easing: quintInOut}}
+    out:fade={{easing: quintInOut}}>
+    {#if event.date !== null}
+      <CopyTimeDropdown class="ml-1" event={event}>
+        <span slot="button-text"><time datetime={dateStringToDisplay}>{format(parseISO(dateStringToDisplay), "PPPPp")}</time></span>
+      </CopyTimeDropdown>
+    {/if}
+  </p>
+</div>
 <div class="flex justify-center">
   <Timer start={now} end={parseISO(dateStringToDisplay)} id={event.id}/>
 </div>

--- a/src/routes/event/[id]/edit/+page.svelte
+++ b/src/routes/event/[id]/edit/+page.svelte
@@ -40,19 +40,21 @@
   }
 </script>
 
-<h1 class="text-4xl m-8 font-bold text-center text-ow2-orange dark:text-ow2-light-orange whitespace-pre-line">Edit {event.title}</h1>
+<div>
+  <h1 class="text-4xl m-8 font-bold text-center text-ow2-orange dark:text-ow2-light-orange whitespace-pre-line">Edit {event.title}</h1>
 
-<form
-  class="dark:text-white flex flex-col"
-  method="POST"
-  use:enhance={handleFormSubmit}
->
-  <EventForm event={event}>
-    <div slot="submit">
-      {#if form?.error}
-        <p class="w-full bg-red-300 dark:bg-red-700 text-center mt-4 py-1 rounded-sm">{form.error}</p>
-      {/if}
-      <input type="submit" class="bg-ow2-orange dark:bg-ow2-light-orange mt-4 px-2 py-1 w-min text-lg font-semibold rounded-md cursor-pointer" value={submitting ? "Loading..." : "Save"}>
-    </div>
-  </EventForm>
-</form>
+  <form
+    class="dark:text-white flex flex-col"
+    method="POST"
+    use:enhance={handleFormSubmit}
+  >
+    <EventForm event={event}>
+      <div slot="submit">
+        {#if form?.error}
+          <p class="w-full bg-red-300 dark:bg-red-700 text-center mt-4 py-1 rounded-sm">{form.error}</p>
+        {/if}
+        <input type="submit" class="bg-ow2-orange dark:bg-ow2-light-orange mt-4 px-2 py-1 w-min text-lg font-semibold rounded-md cursor-pointer" value={submitting ? "Loading..." : "Save"}>
+      </div>
+    </EventForm>
+  </form>
+</div>

--- a/src/routes/event/new/+page.svelte
+++ b/src/routes/event/new/+page.svelte
@@ -35,19 +35,21 @@
 </script>
 
 
-<h1 class="text-4xl m-8 font-bold text-center text-ow2-orange dark:text-ow2-light-orange">Create a new event</h1>
-<form
-  method="POST"
-  class="dark:text-white flex flex-col "
-  use:enhance={handleFormSubmit}
->
-  <EventForm>
-    <div slot="submit">
-      {#if form?.error}
-        <p class="w-full bg-red-300 dark:bg-red-700 text-center mt-4 py-1 rounded-sm">{form.error}</p>
-      {/if}
-      <input type="submit" class="bg-ow2-orange dark:bg-ow2-light-orange mt-4 px-2 py-1 w-min text-lg font-semibold rounded-md cursor-pointer" value={submitting ? "Loading..." : "Create"}>
-    </div>
-  </EventForm>
+<div>
+  <h1 class="text-4xl m-8 font-bold text-center text-ow2-orange dark:text-ow2-light-orange">Create a new event</h1>
+  <form
+    method="POST"
+    class="dark:text-white flex flex-col "
+    use:enhance={handleFormSubmit}
+  >
+    <EventForm>
+      <div slot="submit">
+        {#if form?.error}
+          <p class="w-full bg-red-300 dark:bg-red-700 text-center mt-4 py-1 rounded-sm">{form.error}</p>
+        {/if}
+        <input type="submit" class="bg-ow2-orange dark:bg-ow2-light-orange mt-4 px-2 py-1 w-min text-lg font-semibold rounded-md cursor-pointer" value={submitting ? "Loading..." : "Create"}>
+      </div>
+    </EventForm>
 
-</form>
+  </form>
+</div>


### PR DESCRIPTION
This PR improves some of the styling on various elements of the site, including the following:

- Cards could jump positions if transitioning from a long event show page to the home page
- The "Event beings/ends on" and the local datetime element are no longer separated by the show page gap
- Card backgrounds now fade on transition
- Post edit/create forms overlapped their headings
