### PR TITLE
time updates

### DIFF
--- a/src/lib/components/_copy_time_dropdown.svelte
+++ b/src/lib/components/_copy_time_dropdown.svelte
@@ -4,19 +4,16 @@
   import { FontAwesomeIcon } from "fontawesome-svelte";
   import Dropdown from "./_dropdown.svelte";
   import CopyTimeButton from "./_copy_time_button.svelte";
-  import type { CountdownDate } from "$lib/types";
-  import { format, parseISO } from "date-fns";
+  import { format } from "date-fns";
 
-  export let event : CountdownDate;
-
-  const dateObj = parseISO(event.date);
+  export let date : Date;
 
   async function copyDiscordTimestamp() {
-    await navigator.clipboard.writeText(`<t:${Math.floor(dateObj.getTime() / 1000)}:f> (<t:${Math.floor(dateObj.getTime() / 1000)}:R>)`);
+    await navigator.clipboard.writeText(`<t:${Math.floor(date.getTime() / 1000)}:f> (<t:${Math.floor(date.getTime() / 1000)}:R>)`);
   }
 
   async function copyNormalTimestamp() {
-    await navigator.clipboard.writeText(format(parseISO(event.date), "PPPPp"))
+    await navigator.clipboard.writeText(format(date, "PPPPp"))
   }
 </script>
 

--- a/src/lib/utils/event_helpers.ts
+++ b/src/lib/utils/event_helpers.ts
@@ -15,3 +15,11 @@ export function isEventHappeningNow(event: CountdownDate, now?: Date) {
     && parseISO(event.date) < now
     && parseISO(event.end_date) > now;
 }
+
+export function eventEffectiveDate(event: CountdownDate, now?: Date) {
+  if (now == undefined) now = new Date();
+
+  if (parseISO(event.date) < now && event.end_date) return event.end_date;
+
+  return event.date;
+}

--- a/src/lib/utils/event_helpers.ts
+++ b/src/lib/utils/event_helpers.ts
@@ -23,3 +23,20 @@ export function eventEffectiveDate(event: CountdownDate, now?: Date) {
 
   return event.date;
 }
+
+export function eventRelationToNow(event: CountdownDate, now?: Date) {
+  if (parseISO(eventEffectiveDate(event)) < now) {
+    if (event.end_date) return "ended";
+    return "happened";
+  }
+
+  if (isEventHappeningNow(event, now)) {
+    return "ends";
+  }
+
+  if (event.end_date) {
+    return "begins";
+  }
+
+   return "occurs";
+}

--- a/src/routes/_event_card.svelte
+++ b/src/routes/_event_card.svelte
@@ -9,13 +9,15 @@
   import CopyTimeDropdown from "$lib/components/_copy_time_dropdown.svelte";
   import type { CountdownDate } from "$lib/types";
   import Timer from "$lib/components/_timer.svelte";
-  import { eventEffectiveDate, titleToSlug } from "$lib/utils/event_helpers";
+  import { eventEffectiveDate, eventRelationToNow, titleToSlug } from "$lib/utils/event_helpers";
 
   export let event: CountdownDate;
   export let now: Date;
   export let additionalDelay = 0;
 
   $: dateStringToDisplay = eventEffectiveDate(event, now);
+
+  $: displayVerb = eventRelationToNow(event, now);
 </script>
 
 <div
@@ -43,7 +45,7 @@
       in:fade={{duration: 500, delay: 350 + additionalDelay}}
       out:fade
     >
-      Event {isEventHappeningNow(event, now) ? "ends" : "begins"} on
+      Event {displayVerb} on
     </p>
     <p
       class="text-center text-lg md:text-xl lg:text-2xl"

--- a/src/routes/_event_card.svelte
+++ b/src/routes/_event_card.svelte
@@ -9,13 +9,13 @@
   import CopyTimeDropdown from "$lib/components/_copy_time_dropdown.svelte";
   import type { CountdownDate } from "$lib/types";
   import Timer from "$lib/components/_timer.svelte";
-  import { isEventHappeningNow, titleToSlug } from "$lib/utils/event_helpers";
+  import { eventEffectiveDate, titleToSlug } from "$lib/utils/event_helpers";
 
   export let event: CountdownDate;
   export let now: Date;
   export let additionalDelay = 0;
 
-  $: displayDate = (isEventHappeningNow(event, now) && event.end_date) ? event.end_date : event?.date;
+  $: dateStringToDisplay = eventEffectiveDate(event, now);
 </script>
 
 <div
@@ -37,7 +37,7 @@
       </a>
     {/if}
   </p>
-  {#if event.id !== -1 && displayDate !== null}
+  {#if event.id !== -1 && dateStringToDisplay !== null}
     <p
       class="text-center text-lg md:text-xl lg:text-2xl"
       in:fade={{duration: 500, delay: 350 + additionalDelay}}
@@ -49,13 +49,13 @@
       class="text-center text-lg md:text-xl lg:text-2xl"
       in:fade="{{duration: 500, delay: 500 + additionalDelay}}"
       out:fade>
-      <CopyTimeDropdown class="ml-1" event={event}>
-        <span slot="button-text"><time datetime={displayDate}>{format(parseISO(displayDate), "PPPPp")}</time></span>
+      <CopyTimeDropdown class="ml-1" date={parseISO(dateStringToDisplay)} {now}>
+        <span slot="button-text"><time datetime={dateStringToDisplay}>{format(parseISO(dateStringToDisplay), "PPPPp")}</time></span>
       </CopyTimeDropdown>
     </p>
   {/if}
   <div class="flex justify-center">
-    <Timer start={now} end={parseISO(displayDate)} id={event.id} {additionalDelay} />
+    <Timer start={now} end={parseISO(dateStringToDisplay)} id={event.id} {additionalDelay} />
   </div>
 </div>
 

--- a/src/routes/event/[id]/[slug]/+page.svelte
+++ b/src/routes/event/[id]/[slug]/+page.svelte
@@ -70,7 +70,7 @@
     in:fade={{duration: 1000, delay: 500, easing: quintInOut}}
     out:fade={{easing: quintInOut}}>
     {#if event.date !== null}
-      <CopyTimeDropdown class="ml-1" event={event}>
+      <CopyTimeDropdown class="ml-1" date={parseISO(dateStringToDisplay)}>
         <span slot="button-text"><time datetime={dateStringToDisplay}>{format(parseISO(dateStringToDisplay), "PPPPp")}</time></span>
       </CopyTimeDropdown>
     {/if}

--- a/src/routes/event/[id]/[slug]/+page.svelte
+++ b/src/routes/event/[id]/[slug]/+page.svelte
@@ -4,7 +4,7 @@
   import CopyTimeDropdown from "$lib/components/_copy_time_dropdown.svelte";
   import Timer from "$lib/components/_timer.svelte";
   import Ow2CLink from "$lib/components/markdown/OW2CLink.svelte";
-  import { isEventHappeningNow, titleToSlug } from '$lib/utils/event_helpers';
+  import { eventRelationToNow, titleToSlug } from '$lib/utils/event_helpers';
   import type { PageData } from "./$types";
 
   import { format, parseISO } from "date-fns";
@@ -32,6 +32,8 @@
     now = new Date();
     animationRequest = requestAnimationFrame(updateTime);
   }
+
+  $: displayVerb = eventRelationToNow(event, now);
 
   onMount(() => {
     if (browser) now = new Date();
@@ -63,7 +65,7 @@
     in:fade={{duration: 1000, delay: 450, easing: quintInOut}}
     out:fade
   >
-    Event {isEventHappeningNow(event, now) ? "ends" : "begins"} on
+    Event {displayVerb} on
   </p>
   <p
     class="text-center text-lg md:text-xl lg:text-2xl"

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,6 +8,9 @@ const config = {
         },
         define: {
                 'import.meta.env.VERCEL_ANALYTICS_ID': JSON.stringify(process.env.VERCEL_ANALYTICS_ID)
+        },
+        build: {
+                sourcemap: true
         }
 };
 


### PR DESCRIPTION
This PR adds a small update to how events are described, along with two fixes regarding the copy dropdown not copying the right date, along with events on the homepage not considering the end_date of an event.
