### PR TITLE
fix: Prevent old page from lingering

### DIFF
--- a/src/lib/webVitals.ts
+++ b/src/lib/webVitals.ts
@@ -20,7 +20,7 @@ export interface MetricsOptions {
 function sendToAnalytics(metric: Metric, options: MetricsOptions) {
   const page = Object.entries(options.params).reduce(
     (acc, [key, value]) => acc.replace(value.toString(), `[${key}]`),
-    options.path
+    options.path ?? ""
   );
 
   const body = {

--- a/src/routes/_event_card.svelte
+++ b/src/routes/_event_card.svelte
@@ -39,7 +39,7 @@
       </a>
     {/if}
   </p>
-  {#if event.id !== -1 && dateStringToDisplay !== null}
+  {#if dateStringToDisplay !== null}
     <p
       class="text-center text-lg md:text-xl lg:text-2xl"
       in:fade={{duration: 500, delay: 350 + additionalDelay}}


### PR DESCRIPTION
Due to a strange bug with Svelte or SvelteKit, elements were previously not being properly transitioned out of the DOM during page transitions, causing them to linger and block interactions with the new page (or worse, fire their old behavior even though they were not visible).

Although the root cause is as of yet not fully known, the issue appears to related to transitioning elements contained within `{#if}` blocks.