### PR TITLE
feat: Add progress bar for in-progress events

### DIFF
--- a/src/lib/components/_progress_bar.svelte
+++ b/src/lib/components/_progress_bar.svelte
@@ -15,5 +15,5 @@
 </script>
 
 <div class="w-full bg-zinc-300 dark:bg-zinc-700 rounded-full p-1 flex flex-row">
-  <div class="bg-gradient-to-r from-ow2-orange to-ow2-light-orange dark:from-ow2-light-orange dark:to-ow2-orange h-2 rounded-full" style="width: {$usedProgress}%"></div>
+  <div class="bg-gradient-to-r from-ow2-orange to-ow2-light-orange dark:from-ow2-light-orange dark:to-ow2-orange h-2 min-w-[0.5rem] rounded-full" style="width: {$usedProgress}%"></div>
 </div>

--- a/src/lib/components/_progress_bar.svelte
+++ b/src/lib/components/_progress_bar.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { tweened } from "svelte/motion";
+  import { cubicOut } from "svelte/easing";
+
+  /**
+   * The percentage progress to display. 100 is the max.
+   */
+  export let progress = 50;
+  $: usedProgress.set(progress);
+
+  let usedProgress = tweened(0, {
+    duration: 400,
+    easing: cubicOut
+  });
+</script>
+
+<div class="w-full bg-zinc-300 dark:bg-zinc-700 rounded-full p-1 flex flex-row">
+  <div class="bg-gradient-to-r from-ow2-orange to-ow2-light-orange dark:from-ow2-light-orange dark:to-ow2-orange h-2 rounded-full" style="width: {$usedProgress}%"></div>
+</div>

--- a/src/lib/components/_timer.svelte
+++ b/src/lib/components/_timer.svelte
@@ -45,7 +45,7 @@
 
 <div class="relative flex justify-center gap-12 md:gap-20 lg:gap-28 my-6 w-80 md:w-[36rem] lg:w-[40rem]">
   {#each timerValues as timerValue, i (timerValue.units)}
-    <div in:fade="{{ duration: 500, delay: i * 100 + 700 + additionalDelay }}"
+    <div in:fade="{{ duration: 500, delay: i * 100 + additionalDelay }}"
       out:fly="{{ duration: 500, y: 20 }}"
       animate:flip
     >

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -51,10 +51,9 @@
       });
     }
 
-  let animationRequest : number;
-  function updateTime(timestamp : DOMHighResTimeStamp) {
+  let timeUpdateInterval : NodeJS.Timer;
+  function updateTime() {
     now = new Date();
-    animationRequest = requestAnimationFrame(updateTime);
     if (nextAttemptMarker !== undefined) {
       timeToNextAttempt = formatDistanceStrict(nextAttemptMarker, now, { unit: "second", roundingMethod: "ceil" });
     }
@@ -79,13 +78,13 @@
   onMount(async () => {
     if (browser) now = new Date();
     await updateDates();
-    if (browser) animationRequest = window.requestAnimationFrame(updateTime);
+    if (browser) timeUpdateInterval = setInterval(updateTime, 100);
     loading = false;
   });
 
   onDestroy(() => {
     clearTimeout(dateUpdateTimer);
-    if (browser) window.cancelAnimationFrame(animationRequest);
+    if (browser) clearInterval(timeUpdateInterval);
   })
 
 </script>
@@ -110,7 +109,7 @@
 <div class="grid grid-cols-1 gap-8 self-start items-center my-8 w-full dark:text-zinc-50">
   {#if displayDates?.length != undefined && displayDates.length > 0}
     {#each displayDates as event, eventIndex (event.id)}
-      <div class="justify-self-center" animate:flip>
+      <div class="justify-self-center" animate:flip="{{duration: 500}}">
         <EventCard {now} {event} additionalDelay={eventIndex * 150} />
       </div>
     {/each}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -125,7 +125,7 @@
   {/if}
 </div>
 {#if $page.data.session}
-  <a href="/event/new" class="fixed bottom-8 right-8 p-4 rounded-md dark:text-white bg-zinc-200 dark:bg-zinc-800 hover:bg-zinc-300 hover:dark:bg-zinc-700 hover:underline transition-colors ease-out duration-200 shadow-lg shadow-gray-900">
+  <a href="/event/new" class="fixed bottom-8 right-8 p-4 rounded-md dark:text-white bg-zinc-200 dark:bg-zinc-800 hover:bg-zinc-300 hover:dark:bg-zinc-700 hover:underline transition-colors ease-out duration-200 shadow-lg shadow-gray-900 z-10">
     <FontAwesomeIcon icon={faPlus}/><span class="pl-2 font-semibold">New Event</span>
   </a>
 {/if}

--- a/src/routes/_event_card.svelte
+++ b/src/routes/_event_card.svelte
@@ -22,7 +22,7 @@
 
   let eventDurationInSeconds: number;
   let timeRemainingInSeconds: number;
-  $: if (isEventHappeningNow(event)) {
+  $: if (isEventHappeningNow(event, now)) {
     eventDurationInSeconds = differenceInSeconds(parseISO(event.date), parseISO(event.end_date));
     timeRemainingInSeconds = differenceInSeconds(now, parseISO(event.end_date), { roundingMethod: "ceil" })
   }
@@ -69,7 +69,7 @@
       </CopyTimeDropdown>
     </p>
   {/if}
-  {#if isEventHappeningNow(event)}
+  {#if isEventHappeningNow(event, now)}
     <div
       class="mt-2.5"
       in:fade="{{duration: 500, delay: 600 + additionalDelay}}">

--- a/src/routes/_event_card.svelte
+++ b/src/routes/_event_card.svelte
@@ -62,7 +62,7 @@
     </p>
   {/if}
   <div class="flex justify-center">
-    <Timer start={now} end={parseISO(dateStringToDisplay)} id={event.id} {additionalDelay} />
+    <Timer start={now} end={parseISO(dateStringToDisplay)} id={event.id} additionalDelay={additionalDelay + 700} />
   </div>
 </div>
 

--- a/src/routes/_event_card.svelte
+++ b/src/routes/_event_card.svelte
@@ -71,7 +71,7 @@
   {/if}
   {#if isEventHappeningNow(event)}
     <div
-      class="mt-2"
+      class="mt-2.5"
       in:fade="{{duration: 500, delay: 600 + additionalDelay}}">
       <ProgressBar progress={100 - timeRemainingInSeconds / eventDurationInSeconds * 100} />
     </div>

--- a/src/routes/_event_card.svelte
+++ b/src/routes/_event_card.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { format, parseISO } from "date-fns"
+  import { differenceInSeconds, format, parseISO } from "date-fns"
 
   import { faCircleInfo } from "@fortawesome/free-solid-svg-icons";
   import { FontAwesomeIcon } from "fontawesome-svelte";
@@ -9,7 +9,8 @@
   import CopyTimeDropdown from "$lib/components/_copy_time_dropdown.svelte";
   import type { CountdownDate } from "$lib/types";
   import Timer from "$lib/components/_timer.svelte";
-  import { eventEffectiveDate, eventRelationToNow, titleToSlug } from "$lib/utils/event_helpers";
+  import { eventEffectiveDate, eventRelationToNow, titleToSlug, isEventHappeningNow } from "$lib/utils/event_helpers";
+  import ProgressBar from "$lib/components/_progress_bar.svelte";
 
   export let event: CountdownDate;
   export let now: Date;
@@ -18,6 +19,13 @@
   $: dateStringToDisplay = eventEffectiveDate(event, now);
 
   $: displayVerb = eventRelationToNow(event, now);
+
+  let eventDurationInSeconds: number;
+  let timeRemainingInSeconds: number;
+  $: if (isEventHappeningNow(event)) {
+    eventDurationInSeconds = differenceInSeconds(parseISO(event.date), parseISO(event.end_date));
+    timeRemainingInSeconds = differenceInSeconds(now, parseISO(event.end_date), { roundingMethod: "ceil" })
+  }
 </script>
 
 <div
@@ -60,6 +68,13 @@
         <span slot="button-text"><time datetime={dateStringToDisplay}>{format(parseISO(dateStringToDisplay), "PPPPp")}</time></span>
       </CopyTimeDropdown>
     </p>
+  {/if}
+  {#if isEventHappeningNow(event)}
+    <div
+      class="mt-2"
+      in:fade="{{duration: 500, delay: 600 + additionalDelay}}">
+      <ProgressBar progress={100 - timeRemainingInSeconds / eventDurationInSeconds * 100} />
+    </div>
   {/if}
   <div class="flex justify-center">
     <Timer start={now} end={parseISO(dateStringToDisplay)} id={event.id} additionalDelay={additionalDelay + 700} />

--- a/src/routes/event/[id]/[slug]/+page.svelte
+++ b/src/routes/event/[id]/[slug]/+page.svelte
@@ -4,11 +4,11 @@
   import CopyTimeDropdown from "$lib/components/_copy_time_dropdown.svelte";
   import Timer from "$lib/components/_timer.svelte";
   import Ow2CLink from "$lib/components/markdown/OW2CLink.svelte";
-  import { eventRelationToNow, titleToSlug } from '$lib/utils/event_helpers';
+  import { eventRelationToNow, titleToSlug, isEventHappeningNow } from '$lib/utils/event_helpers';
   import { markdownToPlaintext } from "$lib/utils/string_helpers";
   import type { PageData } from "./$types";
 
-  import { format, parseISO } from "date-fns";
+  import { format, parseISO, differenceInSeconds } from "date-fns";
   import SvelteMarkdown from "svelte-markdown";
 
   import { FontAwesomeIcon } from "fontawesome-svelte";
@@ -20,6 +20,7 @@
   import { fade } from "svelte/transition";
   import { enhance } from "$app/forms";
   import { goto } from "$app/navigation";
+  import ProgressBar from "$lib/components/_progress_bar.svelte";
 
   export let data: PageData;
   let event: CountdownDate;
@@ -39,6 +40,13 @@
   }
 
   $: displayVerb = eventRelationToNow(event, now);
+
+  let eventDurationInSeconds: number;
+  let timeRemainingInSeconds: number;
+  $: if (isEventHappeningNow(event, now)) {
+    eventDurationInSeconds = differenceInSeconds(parseISO(event.date), parseISO(event.end_date));
+    timeRemainingInSeconds = differenceInSeconds(now, parseISO(event.end_date), { roundingMethod: "ceil" })
+  }
 
   onMount(() => {
     if (browser) now = new Date();
@@ -89,6 +97,13 @@
     {/if}
   </p>
 </div>
+{#if isEventHappeningNow(event, now)}
+  <div
+    class="mt-2.5 w-3/4"
+    in:fade="{{duration: 500, delay: 600}}">
+    <ProgressBar progress={100 - timeRemainingInSeconds / eventDurationInSeconds * 100} />
+  </div>
+{/if}
 <div class="flex justify-center">
   <Timer start={now} end={parseISO(dateStringToDisplay)} id={event.id} additionalDelay={700}/>
 </div>

--- a/src/routes/event/[id]/[slug]/+page.svelte
+++ b/src/routes/event/[id]/[slug]/+page.svelte
@@ -90,7 +90,7 @@
   </p>
 </div>
 <div class="flex justify-center">
-  <Timer start={now} end={parseISO(dateStringToDisplay)} id={event.id}/>
+  <Timer start={now} end={parseISO(dateStringToDisplay)} id={event.id} additionalDelay={700}/>
 </div>
 {#if event.description}
   <div


### PR DESCRIPTION
This PR adds a progress bar which appears when the corresponding event is in-progress and showcases the fraction of the event's duration that has elapsed.

![Example of events with a progress bar](https://user-images.githubusercontent.com/10406383/222809786-b58e05d5-2cc3-4fc3-9d4e-4927193d84fa.png)
