### PR TITLE
feat: Add embed for creating embeddable browser source

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@vercel/analytics": "^0.1.8",
     "autoprefixer": "^10.4.5",
     "date-fns": "^2.28.0",
+    "date-fns-tz": "^2.0.0",
     "eslint": "^7.32.0",
     "eslint-plugin-svelte3": "^3.2.1",
     "fontawesome-svelte": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "sanitize-html": "^2.8.1",
     "svelte": "^3.54.0",
     "svelte-check": "^2.2.6",
-    "svelte-confetti": "^1.2.0",
+    "svelte-confetti": "^1.2.2",
     "svelte-markdown": "^0.2.3",
     "svelte-preprocess": "^4.10.1",
     "tailwindcss": "^3.0.24",

--- a/src/app.html
+++ b/src/app.html
@@ -12,10 +12,6 @@
 		<link rel="icon" type="image/png" href="%sveltekit.assets%/favicons/favicon-16x16.png" sizes="16x16" />
 		<link rel="apple-touch-icon" href="%sveltekit.assets%/favicons/apple-touch-icon.png" sizes="600x600"/>
 
-		<meta name="twitter:card" content="summary" />
-		<meta name="twitter:site" content="@Cactus_Puppy" />
-		<meta name="twitter:creator" content="@Cactus_Puppy" />
-
 		<meta name="og:type" content="website" />
 
 		<meta name="application-name" content="OW2Countdown" />

--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,5 +1,6 @@
+import { dev } from "$app/environment";
 import { inject } from '@vercel/analytics';
 
-inject();
+inject({ mode: dev ? "development" : "production" });
 
 import "$lib/client";

--- a/src/lib/components/markdown/Heading.svelte
+++ b/src/lib/components/markdown/Heading.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  export let depth: number;
+</script>
+
+{#if depth === 1}
+  <h1 class="font-bold text-4xl py-4"><slot></slot></h1>
+{:else if depth === 2}
+  <h2 class="font-bold text-3xl py-3"><slot></slot></h2>
+{:else if depth === 3}
+  <h3 class="font-bold text-2xl py-2"><slot></slot></h3>
+{:else if depth === 4}
+  <h4 class="font-bold text-xl py-2"><slot></slot></h4>
+{:else if depth === 5}
+  <h5 class="font-bold text-lg py-2"><slot></slot></h5>
+{:else if depth === 6}
+  <h6 class="font-bold"><slot></slot></h6>
+{:else}
+  <slot></slot>
+{/if}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -31,7 +31,7 @@
   });
 </script>
 
-<div class="wrapper min-h-screen max-w-full overflow-x-hidden mx-2">
+<div class="wrapper min-h-screen max-w-[100dvw] overflow-x-hidden px-2">
   <main class="main__wrapper max-w-full mx-auto relative">
     <slot />
   </main>

--- a/src/routes/event/[id]/[slug]/+layout.svelte
+++ b/src/routes/event/[id]/[slug]/+layout.svelte
@@ -7,16 +7,4 @@
   class="self-start flex flex-col gap-4 items-center w-full dark:text-zinc-50"
 >
   <slot />
-  <a href="/"
-    class="max-w-3xl px-6 py-3 md:px-8 md:py-4
-      text-lg md:text-xl focus:underline hover:underline text-ow2-orange dark:text-ow2-light-orange
-      rounded-md cursor-pointer
-      bg-zinc-200 hover:bg-zinc-300 dark:bg-zinc-800 dark:hover:bg-zinc-700
-      hover:shadow-lg hover:shadow-gray-900 hover:-translate-y-0.5 hover:active:shadow hover:active:translate-y-0
-      transition-colors transition-shadow transition-transform"
-    in:fade={{ duration: 500, delay: 900, easing: quintInOut }}
-    out:fade={{ easing: quintInOut }}
-  >
-    View All Events
-  </a>
 </div>

--- a/src/routes/event/[id]/[slug]/+page.svelte
+++ b/src/routes/event/[id]/[slug]/+page.svelte
@@ -22,6 +22,8 @@
   import { goto } from "$app/navigation";
   import ProgressBar from "$lib/components/_progress_bar.svelte";
 
+  import EmbedBuilder from "./_embed_builder.svelte";
+
   export let data: PageData;
   let event: CountdownDate;
   $: event = data.event;
@@ -152,6 +154,10 @@
     </form>
   </div>
 {/if}
+
+<h2 class="text-2xl">Stream Browser Source Builder</h2>
+
+<EmbedBuilder {event} />
 
 <style>
   .event__title {

--- a/src/routes/event/[id]/[slug]/+page.svelte
+++ b/src/routes/event/[id]/[slug]/+page.svelte
@@ -4,6 +4,7 @@
   import CopyTimeDropdown from "$lib/components/_copy_time_dropdown.svelte";
   import Timer from "$lib/components/_timer.svelte";
   import Ow2CLink from "$lib/components/markdown/OW2CLink.svelte";
+  import Heading from "$lib/components/markdown/Heading.svelte";
   import { eventRelationToNow, titleToSlug, isEventHappeningNow } from '$lib/utils/event_helpers';
   import { markdownToPlaintext } from "$lib/utils/string_helpers";
   import type { PageData } from "./$types";
@@ -118,7 +119,8 @@
     <SvelteMarkdown
       source={event.description}
       renderers={{
-        "link": Ow2CLink
+        "link": Ow2CLink,
+        "heading": Heading
       }}
     />
   </div>

--- a/src/routes/event/[id]/[slug]/+page.svelte
+++ b/src/routes/event/[id]/[slug]/+page.svelte
@@ -13,7 +13,7 @@
   import SvelteMarkdown from "svelte-markdown";
 
   import { FontAwesomeIcon } from "fontawesome-svelte";
-  import { faPencil, faTrash } from "@fortawesome/free-solid-svg-icons";
+  import { faPencil, faTrash, faChevronRight } from "@fortawesome/free-solid-svg-icons";
 
   import { quintInOut } from "svelte/easing";
   import { browser } from "$app/environment";
@@ -50,6 +50,8 @@
     eventDurationInSeconds = differenceInSeconds(parseISO(event.date), parseISO(event.end_date));
     timeRemainingInSeconds = differenceInSeconds(now, parseISO(event.end_date), { roundingMethod: "ceil" })
   }
+
+  let isEmbedBuilderOpen = false;
 
   onMount(() => {
     if (browser) now = new Date();
@@ -157,9 +159,36 @@
   </div>
 {/if}
 
-<h2 class="text-2xl">Stream Browser Source Builder</h2>
+<a href="/"
+    class="max-w-3xl px-6 py-3 md:px-8 md:py-4
+      text-lg md:text-xl focus:underline hover:underline text-ow2-orange dark:text-ow2-light-orange
+      rounded-md cursor-pointer
+      bg-zinc-200 hover:bg-zinc-300 dark:bg-zinc-800 dark:hover:bg-zinc-700
+      hover:shadow-lg hover:shadow-gray-900 hover:-translate-y-0.5 hover:active:shadow hover:active:translate-y-0
+      transition-colors transition-shadow transition-transform"
+    in:fade={{ duration: 500, delay: 900, easing: quintInOut }}
+    out:fade={{ easing: quintInOut }}
+  >
+    View All Events
+  </a>
 
-<EmbedBuilder {event} />
+<button
+  aria-expanded="true"
+  aria-haspopup="true"
+  on:click={ () => isEmbedBuilderOpen = !isEmbedBuilderOpen }
+  class="flex items-center"
+>
+  <p class="text-2xl">Stream Embed Builder</p>
+  <div class={"ml-4 transition-transform" + (isEmbedBuilderOpen ? " rotate-90" : "")}>
+    <FontAwesomeIcon icon={faChevronRight} />
+  </div>
+</button>
+
+{#if isEmbedBuilderOpen}
+  <div transition:fade>
+    <EmbedBuilder {event} />
+  </div>
+{/if}
 
 <style>
   .event__title {

--- a/src/routes/event/[id]/[slug]/+page.svelte
+++ b/src/routes/event/[id]/[slug]/+page.svelte
@@ -185,9 +185,7 @@
 </button>
 
 {#if isEmbedBuilderOpen}
-  <div transition:fade>
-    <EmbedBuilder {event} />
-  </div>
+  <EmbedBuilder {event} />
 {/if}
 
 <style>

--- a/src/routes/event/[id]/[slug]/_embed_builder.svelte
+++ b/src/routes/event/[id]/[slug]/_embed_builder.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import type { CountdownDate } from "$lib/types";
+  import { titleToSlug } from "$lib/utils/event_helpers";
+
+  import Embed from "./embed/_embed.svelte";
+
+  export let event: CountdownDate;
+
+  let embedOptions: Record<string, boolean> = {
+    "title": true,
+    "timestamp": false,
+    "progress_bar": false
+  }
+
+  let baseEmbedURL: string;
+  $: baseEmbedURL = `/event/${event.id}/${titleToSlug(event.title)}/embed`;
+
+  let finalURL: string;
+  $: finalURL = `${baseEmbedURL}?${(new URLSearchParams(Object.entries(embedOptions).filter(([key, value]) => value).map(([key, value]) => [key, "1"])))}`;
+</script>
+
+<div class="flex flex-col items-center">
+  <div class="embed_build__options">
+    <h3 class="text-center">Embed Options</h3>
+
+    <label>
+      <input type="checkbox" name="title" bind:checked={embedOptions["title"]} />
+      Title
+    </label>
+
+    <label>
+      <input type="checkbox" name="timestamp" bind:checked={embedOptions["timestamp"]} />
+      Timestamp
+    </label>
+
+    <label>
+      <input type="checkbox" name="progress_bar" bind:checked={embedOptions["progress_bar"]} />
+      Progress Bar
+    </label>
+  </div>
+  <a href={finalURL} target="_blank" rel="noreferrer" class="underline text-ow2-orange dark:text-ow2-light-orange">{"https://workshop.codes" + finalURL}</a>
+  <Embed
+    {event}
+    title={embedOptions["title"]}
+    timestamp={embedOptions["timestamp"]}
+    progressBar={embedOptions["progress_bar"]} />
+</div>
+
+<style>
+  .embed_build__options > label {
+    padding: 0.25rem;
+    border-radius: 0.25rem;
+    @apply bg-zinc-300;
+  }
+
+  :global(.dark) .embed_build__options > label {
+    @apply bg-zinc-700;
+  }
+</style>

--- a/src/routes/event/[id]/[slug]/_embed_builder.svelte
+++ b/src/routes/event/[id]/[slug]/_embed_builder.svelte
@@ -49,28 +49,28 @@
 
 <div class="flex flex-col items-center max-w-full" transition:fade>
   <div class="embed_build__options">
-    <div>
+    <div class="min-w-max">
       <label class="embed-option">
         <input class="embed-option__input" type="checkbox" name="title" bind:checked={embedOptions["title"]} />
         <span class="embed-option__span">Title</span>
       </label>
     </div>
 
-    <div>
+    <div class="min-w-max">
       <label class="embed-option">
         <input class="embed-option__input" type="checkbox" name="timestamp" bind:checked={embedOptions["timestamp"]} />
         <span class="embed-option__span">Timestamp</span>
       </label>
     </div>
 
-    <div>
+    <div class="min-w-max">
       <label class="embed-option">
         <input class="embed-option__input" type="checkbox" name="progress_bar" bind:checked={embedOptions["progress_bar"]} />
         <span class="embed-option__span">Progress Bar</span>
       </label>
     </div>
 
-    <div>
+    <div class="min-w-max">
       <label class="embed-option">
         <input class="embed-option__input" type="checkbox" name="dark_mode" bind:checked={embedOptions["dark_mode"]} />
         <span class="embed-option__span">Dark Mode</span>
@@ -79,7 +79,7 @@
   </div>
   <button
     on:click={handleClick}
-    class="flex items-center relative max-w-sm sm:max-w-md md:max-w-xl lg:max-w-2xl mt-4 rounded bg-zinc-200 dark:bg-zinc-800 p-1 cursor-pointer font-mono text-ow2-orange dark:text-ow2-light-orange whitespace-nowrap"
+    class="flex items-center relative max-w-xs sm:max-w-md md:max-w-xl lg:max-w-2xl mt-4 rounded bg-zinc-200 dark:bg-zinc-800 p-1 cursor-pointer font-mono text-ow2-orange dark:text-ow2-light-orange whitespace-nowrap"
   >
     <FontAwesomeIcon icon={faCopy} />
     <p class="ml-2 overflow-hidden">{"https://ow2countdown.com" + finalPath}</p>
@@ -106,6 +106,7 @@
 <style>
   .embed_build__options {
     display: flex;
+    flex-wrap: wrap;
     gap: 1.25rem;
     max-width: 100%;
   }

--- a/src/routes/event/[id]/[slug]/_embed_builder.svelte
+++ b/src/routes/event/[id]/[slug]/_embed_builder.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import type { CountdownDate } from "$lib/types";
   import { titleToSlug } from "$lib/utils/event_helpers";
+  import { fade } from "svelte/transition";
+  import { FontAwesomeIcon } from "fontawesome-svelte";
+  import { faCopy, faChevronRight } from "@fortawesome/free-solid-svg-icons";
 
   import Embed from "./embed/_embed.svelte";
 
@@ -17,12 +20,29 @@
 
   let finalURL: string;
   $: finalURL = `${baseEmbedURL}?${(new URLSearchParams(Object.entries(embedOptions).filter(([key, value]) => value).map(([key, value]) => [key, "1"])))}`;
+
+  async function handleClick() {
+    await navigator.clipboard.writeText("https://ow2countdown.com" + finalURL);
+    fadeInOutCopyConfirmation();
+  }
+
+  let copyNotification: HTMLDivElement;
+  function fadeInOutCopyConfirmation() {
+    copyNotification.animate([
+        { opacity: 0, offset: 0 },
+        { opacity: 0.85, offset: 0.05 },
+        { opacity: 0.85, offset: 0.95 },
+        { opacity: 0, offset: 1.0 }
+      ],
+      1000
+    );
+  }
+
+  let showPreview = false;
 </script>
 
 <div class="flex flex-col items-center">
   <div class="embed_build__options">
-    <h3 class="text-center">Embed Options</h3>
-
     <label>
       <input type="checkbox" name="title" bind:checked={embedOptions["title"]} />
       Title
@@ -38,22 +58,34 @@
       Progress Bar
     </label>
   </div>
-  <a href={finalURL} target="_blank" rel="noreferrer" class="underline text-ow2-orange dark:text-ow2-light-orange">{"https://workshop.codes" + finalURL}</a>
-  <Embed
-    {event}
-    title={embedOptions["title"]}
-    timestamp={embedOptions["timestamp"]}
-    progressBar={embedOptions["progress_bar"]} />
+  <button
+    on:click={handleClick}
+    class="flex items-center relative max-w-xl mt-4 rounded bg-zinc-200 dark:bg-zinc-800 p-1 cursor-pointer font-mono text-ow2-orange dark:text-ow2-light-orange whitespace-nowrap"
+  >
+    <FontAwesomeIcon icon={faCopy} />
+    <p class="ml-2 overflow-hidden">{"https://ow2countdown.com" + finalURL}</p>
+    <div class="absolute inset-0 opacity-0 bg-zinc-200 dark:bg-zinc-800 pointer-events-none" bind:this={copyNotification}>
+      <p class="m-auto translate-y-1">(copied)</p>
+    </div>
+  </button>
+  <button class="flex items-center text-xl mt-4 hover:underline focus-visible:underline" on:click={() => showPreview = !showPreview}>
+    <p>{showPreview ? "Hide" : "Show"} Preview</p>
+    <div class={"ml-4 text-base transition-transform" + (showPreview ? " rotate-90" : "")}><FontAwesomeIcon icon={faChevronRight} /></div>
+  </button>
+  {#if showPreview}
+    <div transition:fade>
+      <Embed
+        {event}
+        title={embedOptions["title"]}
+        timestamp={embedOptions["timestamp"]}
+        progressBar={embedOptions["progress_bar"]} />
+    </div>
+  {/if}
 </div>
 
 <style>
   .embed_build__options > label {
     padding: 0.25rem;
     border-radius: 0.25rem;
-    @apply bg-zinc-300;
-  }
-
-  :global(.dark) .embed_build__options > label {
-    @apply bg-zinc-700;
   }
 </style>

--- a/src/routes/event/[id]/[slug]/embed/+page.ts
+++ b/src/routes/event/[id]/[slug]/embed/+page.ts
@@ -2,14 +2,14 @@ import { error, redirect } from "@sveltejs/kit";
 import type { PageLoad } from "./$types";
 import { titleToSlug } from '$lib/utils/event_helpers'
 
-export const load: PageLoad = async ({ params, fetch }) => {
+export const load: PageLoad = async ({ url, params, fetch }) => {
   const response = await fetch(`/api/event/${params.id}`);
 
   if (!response.ok) throw error(response.status, response.statusText);
 
   const result = await response.json();
 
-  if (titleToSlug(result.title) !== params.slug) throw redirect(301, `/event/${params.id}/${titleToSlug(result.title)}/embed`)
+  if (titleToSlug(result.title) !== params.slug) throw redirect(301, `/event/${params.id}/${titleToSlug(result.title)}/embed${url.searchParams.toString() != "" ? `?${url.searchParams.toString()}` : ""}`)
 
   return {
     event: result

--- a/src/routes/event/[id]/[slug]/embed/+page.ts
+++ b/src/routes/event/[id]/[slug]/embed/+page.ts
@@ -1,0 +1,17 @@
+import { error, redirect } from "@sveltejs/kit";
+import type { PageLoad } from "./$types";
+import { titleToSlug } from '$lib/utils/event_helpers'
+
+export const load: PageLoad = async ({ params, fetch }) => {
+  const response = await fetch(`/api/event/${params.id}`);
+
+  if (!response.ok) throw error(response.status, response.statusText);
+
+  const result = await response.json();
+
+  if (titleToSlug(result.title) !== params.slug) throw redirect(301, `/event/${params.id}/${titleToSlug(result.title)}/embed`)
+
+  return {
+    event: result
+  }
+}

--- a/src/routes/event/[id]/[slug]/embed/+page@.svelte
+++ b/src/routes/event/[id]/[slug]/embed/+page@.svelte
@@ -1,76 +1,19 @@
 <script lang="ts">
-  import { onDestroy, onMount } from "svelte";
-  import { browser } from "$app/environment";
   import { page } from "$app/stores";
 
-  import type { PageData } from "./$types";
-  import { eventRelationToNow, isEventHappeningNow } from '$lib/utils/event_helpers';
   import type { CountdownDate } from "$lib/types";
+  import type { PageData } from "./$types";
 
-  import ProgressBar from "$lib/components/_progress_bar.svelte";
-  import Timer from "$lib/components/_timer.svelte";
-
-  import { differenceInSeconds, format, parseISO } from "date-fns";
-  import { formatInTimeZone } from "date-fns-tz";
+  import Embed from "./_embed.svelte";
 
   export let data: PageData;
   let event: CountdownDate;
   $: event = data.event;
-
-  let now: Date;
-  const EVENT_ARRIVAL_LINGER_TIME_SECONDS = 3;
-  $: dateStringToDisplay = (now && event.date && now.getTime() > parseISO(event.date).getTime() + EVENT_ARRIVAL_LINGER_TIME_SECONDS * 1000 && event.end_date) ? event.end_date : event.date;
-  let animationRequest: number;
-  function updateTime() {
-    now = new Date();
-    animationRequest = requestAnimationFrame(updateTime);
-  }
-
-  $: displayVerb = eventRelationToNow(event, now);
-
-  let eventDurationInSeconds: number;
-  let timeRemainingInSeconds: number;
-  $: if (isEventHappeningNow(event, now)) {
-    eventDurationInSeconds = differenceInSeconds(parseISO(event.date), parseISO(event.end_date));
-    timeRemainingInSeconds = differenceInSeconds(now, parseISO(event.end_date), { roundingMethod: "ceil" })
-  }
-
-  onMount(() => {
-    if (browser) now = new Date();
-    if (browser) animationRequest = window.requestAnimationFrame(updateTime);
-  })
-
-  onDestroy(() => {
-    if (browser) cancelAnimationFrame(animationRequest);
-  })
 </script>
 
-<div class="w-full flex flex-col gap-4 items-center dark:text-zinc-50">
-  {#if $page.url.searchParams.get("title")}
-    <h1 class="mx-4 mt-10 text-center text-5xl text-ow2-orange dark:text-ow2-light-orange">{event.title}</h1>
-  {/if}
-  {#if $page.url.searchParams.get("timestamp")}
-    <div>
-      <p
-        class="text-center text-lg md:text-xl lg:text-2xl"
-      >
-        Event {displayVerb} on
-      </p>
-      <p
-        class="text-center text-lg md:text-xl lg:text-2xl"
-      >
-        {#if event.date !== null}
-          <time datetime={dateStringToDisplay}>{formatInTimeZone(parseISO(dateStringToDisplay), $page.url.searchParams.get("timezone") ?? "America/Los_Angeles", "PPPPp zzz")}</time>
-        {/if}
-      </p>
-    </div>
-  {/if}
-  {#if isEventHappeningNow(event, now) && $page.url.searchParams.get("progress_bar")}
-  <div
-    class="mt-2.5 w-3/4"
-  >
-    <ProgressBar progress={100 - timeRemainingInSeconds / eventDurationInSeconds * 100} />
-  </div>
-{/if}
-  <Timer start={now} end={parseISO(dateStringToDisplay)} id={event.id} additionalDelay={700}/>
-</div>
+<Embed
+  title={$page.url.searchParams.has("title")}
+  timestamp={$page.url.searchParams.has("timestamp")}
+  progressBar={$page.url.searchParams.has("progress_bar")}
+  timezone={$page.url.searchParams.get("timezone")}
+  {event} />

--- a/src/routes/event/[id]/[slug]/embed/+page@.svelte
+++ b/src/routes/event/[id]/[slug]/embed/+page@.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import { onDestroy, onMount } from "svelte";
+  import { browser } from "$app/environment";
+
+  import type { PageData } from "./$types";
+  import type { CountdownDate } from "$lib/types";
+
+  import Timer from "$lib/components/_timer.svelte";
+
+  import { parseISO } from "date-fns";
+
+  let now: Date;
+  const EVENT_ARRIVAL_LINGER_TIME_SECONDS = 3;
+  $: dateStringToDisplay = (now && event.date && now.getTime() > parseISO(event.date).getTime() + EVENT_ARRIVAL_LINGER_TIME_SECONDS * 1000 && event.end_date) ? event.end_date : event.date;
+  let animationRequest: number;
+  function updateTime() {
+    now = new Date();
+    animationRequest = requestAnimationFrame(updateTime);
+  }
+
+  export let data: PageData;
+  let event: CountdownDate;
+  $: event = data.event;
+
+  onMount(() => {
+    if (browser) now = new Date();
+    if (browser) animationRequest = window.requestAnimationFrame(updateTime);
+  })
+
+  onDestroy(() => {
+    if (browser) cancelAnimationFrame(animationRequest);
+  })
+</script>
+
+<div class="flex justify-center dark:text-zinc-50">
+  <Timer start={now} end={parseISO(dateStringToDisplay)} id={event.id} additionalDelay={700}/>
+</div>

--- a/src/routes/event/[id]/[slug]/embed/+page@.svelte
+++ b/src/routes/event/[id]/[slug]/embed/+page@.svelte
@@ -1,13 +1,21 @@
 <script lang="ts">
   import { onDestroy, onMount } from "svelte";
   import { browser } from "$app/environment";
+  import { page } from "$app/stores";
 
   import type { PageData } from "./$types";
+  import { eventRelationToNow, isEventHappeningNow } from '$lib/utils/event_helpers';
   import type { CountdownDate } from "$lib/types";
 
+  import ProgressBar from "$lib/components/_progress_bar.svelte";
   import Timer from "$lib/components/_timer.svelte";
 
-  import { parseISO } from "date-fns";
+  import { differenceInSeconds, format, parseISO } from "date-fns";
+  import { formatInTimeZone } from "date-fns-tz";
+
+  export let data: PageData;
+  let event: CountdownDate;
+  $: event = data.event;
 
   let now: Date;
   const EVENT_ARRIVAL_LINGER_TIME_SECONDS = 3;
@@ -18,9 +26,14 @@
     animationRequest = requestAnimationFrame(updateTime);
   }
 
-  export let data: PageData;
-  let event: CountdownDate;
-  $: event = data.event;
+  $: displayVerb = eventRelationToNow(event, now);
+
+  let eventDurationInSeconds: number;
+  let timeRemainingInSeconds: number;
+  $: if (isEventHappeningNow(event, now)) {
+    eventDurationInSeconds = differenceInSeconds(parseISO(event.date), parseISO(event.end_date));
+    timeRemainingInSeconds = differenceInSeconds(now, parseISO(event.end_date), { roundingMethod: "ceil" })
+  }
 
   onMount(() => {
     if (browser) now = new Date();
@@ -32,6 +45,32 @@
   })
 </script>
 
-<div class="flex justify-center dark:text-zinc-50">
+<div class="w-full flex flex-col gap-4 items-center dark:text-zinc-50">
+  {#if $page.url.searchParams.get("title")}
+    <h1 class="mx-4 mt-10 text-center text-5xl text-ow2-orange dark:text-ow2-light-orange">{event.title}</h1>
+  {/if}
+  {#if $page.url.searchParams.get("timestamp")}
+    <div>
+      <p
+        class="text-center text-lg md:text-xl lg:text-2xl"
+      >
+        Event {displayVerb} on
+      </p>
+      <p
+        class="text-center text-lg md:text-xl lg:text-2xl"
+      >
+        {#if event.date !== null}
+          <time datetime={dateStringToDisplay}>{formatInTimeZone(parseISO(dateStringToDisplay), $page.url.searchParams.get("timezone") ?? "America/Los_Angeles", "PPPPp zzz")}</time>
+        {/if}
+      </p>
+    </div>
+  {/if}
+  {#if isEventHappeningNow(event, now) && $page.url.searchParams.get("progress_bar")}
+  <div
+    class="mt-2.5 w-3/4"
+  >
+    <ProgressBar progress={100 - timeRemainingInSeconds / eventDurationInSeconds * 100} />
+  </div>
+{/if}
   <Timer start={now} end={parseISO(dateStringToDisplay)} id={event.id} additionalDelay={700}/>
 </div>

--- a/src/routes/event/[id]/[slug]/embed/_embed.svelte
+++ b/src/routes/event/[id]/[slug]/embed/_embed.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  import { browser } from "$app/environment";
+  import type { CountdownDate } from "$lib/types";
+  import { eventRelationToNow, isEventHappeningNow } from "$lib/utils/event_helpers";
+  import { onDestroy, onMount } from "svelte";
+  import ProgressBar from "$lib/components/_progress_bar.svelte";
+  import Timer from "$lib/components/_timer.svelte";
+
+  import { differenceInSeconds, format, parseISO } from "date-fns";
+  import { formatInTimeZone } from "date-fns-tz";
+
+  export let title: boolean;
+  export let timestamp: boolean;
+  export let progressBar: boolean;
+  export let timezone: string | undefined = undefined;
+
+  export let event: CountdownDate;
+
+  let now: Date;
+  const EVENT_ARRIVAL_LINGER_TIME_SECONDS = 3;
+  $: dateStringToDisplay = (now && event.date && now.getTime() > parseISO(event.date).getTime() + EVENT_ARRIVAL_LINGER_TIME_SECONDS * 1000 && event.end_date) ? event.end_date : event.date;
+  let animationRequest: number;
+  function updateTime() {
+    now = new Date();
+    animationRequest = requestAnimationFrame(updateTime);
+  }
+
+  $: displayVerb = eventRelationToNow(event, now);
+
+  let eventDurationInSeconds: number;
+  let timeRemainingInSeconds: number;
+  $: if (isEventHappeningNow(event, now)) {
+    eventDurationInSeconds = differenceInSeconds(parseISO(event.date), parseISO(event.end_date));
+    timeRemainingInSeconds = differenceInSeconds(now, parseISO(event.end_date), { roundingMethod: "ceil" })
+  }
+
+  onMount(() => {
+    if (browser) now = new Date();
+    if (browser) animationRequest = window.requestAnimationFrame(updateTime);
+  })
+
+  onDestroy(() => {
+    if (browser) cancelAnimationFrame(animationRequest);
+  })
+</script>
+
+<div class="w-full flex flex-col gap-2 items-center dark:text-zinc-50">
+  {#if title}
+    <h1 class="mx-4 mt-2 text-center text-5xl text-ow2-orange dark:text-ow2-light-orange">{event.title}</h1>
+  {/if}
+  {#if timestamp}
+    <div>
+      <p
+        class="text-center text-lg md:text-xl lg:text-2xl"
+      >
+        Event {displayVerb} on
+      </p>
+      <p
+        class="text-center text-lg md:text-xl lg:text-2xl"
+      >
+        {#if event.date !== null}
+          <time datetime={dateStringToDisplay}>{formatInTimeZone(parseISO(dateStringToDisplay), timezone ?? "America/Los_Angeles", "PPPPp zzz")}</time>
+        {/if}
+      </p>
+    </div>
+  {/if}
+  {#if isEventHappeningNow(event, now) && progressBar}
+    <div
+      class="mt-2.5 w-3/4"
+    >
+      <ProgressBar progress={100 - timeRemainingInSeconds / eventDurationInSeconds * 100} />
+    </div>
+  {/if}
+  <Timer start={now} end={parseISO(dateStringToDisplay)} id={event.id} additionalDelay={700}/>
+</div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1933,10 +1933,10 @@ svelte-check@^2.2.6:
     svelte-preprocess "^4.0.0"
     typescript "*"
 
-svelte-confetti@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/svelte-confetti/-/svelte-confetti-1.2.0.tgz#754a5af1c066751c06d6b393ceafb02ffff84fb3"
-  integrity sha512-6njSCc2mzNQpgxd6VnIkS8yhdbL9np9uTpK6bdmbephmLvI0+km0cBdfuM+MLmceVdW9Frx+ibwCFPDq/dBd1g==
+svelte-confetti@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/svelte-confetti/-/svelte-confetti-1.2.2.tgz#87e96d19ce859af40b099535cfd406bf38245770"
+  integrity sha512-LkvWO732jRNmYykWi0IOK7xoBX241p+p+tC7Ef1EcO3TK9b9lpB/vYqKkcwVya+onG2SgQsX2g+JVbVKxq5ixQ==
 
 svelte-hmr@^0.15.1:
   version "0.15.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -726,6 +726,11 @@ d@1, d@^1.0.1:
     es5-ext "^0.10.50"
     type "^1.0.1"
 
+date-fns-tz@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-2.0.0.tgz#1b14c386cb8bc16fc56fe333d4fc34ae1d1099d5"
+  integrity sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==
+
 date-fns@^2.28.0:
   version "2.28.0"
   resolved "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz"


### PR DESCRIPTION
This PR adds a URL which can be used by programs such as OBS Studio to show countdowns via a browser source, and a user-friendly option on event pages to guide non-technical users through the process of creating an embed.

Example path: `/event/87/talantis/embed?title=1`
Result:
![image](https://user-images.githubusercontent.com/10406383/236651026-af71be5a-9843-4878-9aea-0dbc6a70035b.png)
