### PR TITLE
fix: Use `width: 100%` instead of `width: 100vw`

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -126,7 +126,7 @@
       </div>
   {/if}
 
-  <div class="absolute w-screen top-0 bottom-0 pointer-events-none">
+  <div class="absolute w-full top-0 bottom-0 pointer-events-none">
     <div class="relative grid grid-rows-[1fr,auto] h-full w-full">
       <div></div>
       <div class={`sticky bottom-8 flex flex-row-reverse pr-4 sm:pr-8 z-20 pointer-events-none`} transition:fade>

--- a/src/routes/event/[id]/[slug]/+page.svelte
+++ b/src/routes/event/[id]/[slug]/+page.svelte
@@ -168,7 +168,7 @@
     </div>
 
   </div>
-  <div class="absolute w-screen top-0 bottom-0 pointer-events-none" transition:fade>
+  <div class="absolute w-full top-0 bottom-0 pointer-events-none" transition:fade>
     <div class="relative grid grid-rows-[1fr,auto] h-full w-full">
       <div></div>
       <div class={`sticky flex flex-row-reverse bottom-8`}>


### PR DESCRIPTION
Fixes an issue where the screen gets a horizontal scrollbar when the screen overflows vertically because `100vw` is calculated with the size of the vertical scrollbar, making the elements slightly wider than they should be.

![before](https://github.com/CactusPuppy/ow2countdown/assets/6181929/29f4461e-4bf3-423c-aa62-bc039b0baf60)
![after](https://github.com/CactusPuppy/ow2countdown/assets/6181929/8277e509-51ab-4392-bf4f-acd6a2993380)

I wasn't able to test this locally, but I did the changes with DevTools in ow2countdown.com and replicated them in the code. Still, it might be wise to test locally before merging.