### PR TITLE
fix: Prevent previous fix in 3a918cc1 from causing event show page to linger

### DIFF
--- a/src/lib/utils/WidthLimiter.svelte
+++ b/src/lib/utils/WidthLimiter.svelte
@@ -1,7 +1,10 @@
-<script>
+<script lang="ts">
   export let vagueWidthInPx = 900;
+
+  let paddingAmount: string;
+  $: paddingAmount = `min(calc(50dvw - (${vagueWidthInPx}px - 4rem + 20vw) / 2), 100%)`;
 </script>
 
-<div class={$$props.class} style={`max-width: min(calc(${vagueWidthInPx}px - 4rem + 20vw), 100%)`}>
+<div class={$$props.class} style={`padding-left: ${paddingAmount}; padding-right: ${paddingAmount};`}>
   <slot />
 </div>

--- a/src/routes/event/+layout.svelte
+++ b/src/routes/event/+layout.svelte
@@ -3,6 +3,6 @@
   import WidthLimiter from "$lib/utils/WidthLimiter.svelte";
 
 </script>
-<WidthLimiter class="relative mx-auto dark:text-zinc-50">
+<div class="relative w-full dark:text-zinc-50">
   <slot />
-</WidthLimiter>
+</div>

--- a/src/routes/event/[id]/[slug]/+page.svelte
+++ b/src/routes/event/[id]/[slug]/+page.svelte
@@ -7,6 +7,7 @@
   import Heading from "$lib/components/markdown/Heading.svelte";
   import { eventRelationToNow, titleToSlug, isEventHappeningNow } from '$lib/utils/event_helpers';
   import { markdownToPlaintext } from "$lib/utils/string_helpers";
+  import WidthLimiter from "$lib/utils/WidthLimiter.svelte";
   import type { PageData } from "./$types";
 
   import { format, parseISO, differenceInSeconds } from "date-fns";
@@ -118,7 +119,7 @@
     </div>
     {#if event.description}
       <div
-        class="mx-4 mt-2 text-lg md:text-xl max-w-3xl event__description"
+        class="mx-4 mt-2 text-lg md:text-xl max-w-prose event__description"
         in:fade={{ duration: 500, delay: 700 }}
         out:fade={{easing: quintInOut}}
       >
@@ -166,7 +167,6 @@
         <EmbedBuilder {event} />
       {/if}
     </div>
-
   </div>
   <div class="absolute w-full top-0 bottom-0 pointer-events-none" transition:fade>
     <div class="relative grid grid-rows-[1fr,auto] h-full w-full">

--- a/src/routes/event/[id]/edit/+page.svelte
+++ b/src/routes/event/[id]/edit/+page.svelte
@@ -7,6 +7,7 @@
   import { goto } from "$app/navigation";
   import { onMount } from "svelte";
   import type { ActionResult } from "@sveltejs/kit";
+  import WidthLimiter from "$lib/utils/WidthLimiter.svelte";
 
   let submitting = false;
 
@@ -40,7 +41,7 @@
   }
 </script>
 
-<div>
+<WidthLimiter vagueWidthInPx={400} class="mx-auto">
   <h1 class="text-4xl m-8 font-bold text-center text-ow2-orange dark:text-ow2-light-orange whitespace-pre-line">Edit {event.title}</h1>
 
   <form
@@ -57,4 +58,4 @@
       </div>
     </EventForm>
   </form>
-</div>
+</WidthLimiter>

--- a/src/routes/event/new/+page.svelte
+++ b/src/routes/event/new/+page.svelte
@@ -6,6 +6,7 @@
   import { onMount } from "svelte";
 
   import type { ActionData } from "./$types";
+  import WidthLimiter from "$lib/utils/WidthLimiter.svelte";
 
   let submitting = false;
 
@@ -35,8 +36,8 @@
 </script>
 
 
-<div class="px-2">
-  <h1 class="text-4xl m-8 font-bold text-center text-ow2-orange dark:text-ow2-light-orange">Create a new event</h1>
+<WidthLimiter vagueWidthInPx={400} class="mx-auto">
+  <h1 class="text-4xl mt-4 mb-2 font-bold text-center text-ow2-orange dark:text-ow2-light-orange">Create a new event</h1>
   <form
     method="POST"
     class="dark:text-white flex flex-col "
@@ -52,4 +53,4 @@
     </EventForm>
 
   </form>
-</div>
+</WidthLimiter>


### PR DESCRIPTION
This PR provides an alternative fix for Google Chrome that does not cause SvelteKit to retain the event show page when navigating back to Home.
