### PR TITLE
perf: Lazy load images on event page

### DIFF
--- a/src/lib/components/markdown/Image.svelte
+++ b/src/lib/components/markdown/Image.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  export let href = "";
+  export let title = undefined;
+  export let text = "";
+</script>
+
+<img src={href} {title} alt={text} loading="lazy">

--- a/src/routes/event/[id]/[slug]/+page.svelte
+++ b/src/routes/event/[id]/[slug]/+page.svelte
@@ -25,6 +25,7 @@
   import ProgressBar from "$lib/components/_progress_bar.svelte";
 
   import EmbedBuilder from "./_embed_builder.svelte";
+  import Image from "$lib/components/markdown/Image.svelte";
 
   export let data: PageData;
   let event: CountdownDate;
@@ -127,7 +128,8 @@
           source={event.description}
           renderers={{
             "link": Ow2CLink,
-            "heading": Heading
+            "heading": Heading,
+            "image": Image
           }}
         />
       </div>


### PR DESCRIPTION
This PR marks images included via Markdown to be lazy-loaded. This change is intended to improve page loading times by only loading images when necessary.
