### PR TITLE
fix: Reduce "Home" button width on error page

### DIFF
--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -23,11 +23,4 @@
   >
     Page Not Found
   </p>
-  <a
-    class="self-center px-4 py-2 my-4 rounded bg-zinc-200 dark:bg-zinc-800 hover:bg-zinc-300 dark:hover:bg-zinc-700 text-center text-lg md:text-xl lg:text-2xl dark:text-zinc-50 hover:underline hover:text-ow2-orange dark:hover:text-ow2-light-orange transition-colors"
-    in:fade={{duration: 500, delay: 1000, easing: quintInOut}}
-    out:fade
-    href="/">
-    Home
-  </a>
 </div>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -24,7 +24,7 @@
     Page Not Found
   </p>
   <a
-    class="px-4 py-2 my-4 rounded bg-zinc-200 dark:bg-zinc-800 hover:bg-zinc-300 dark:hover:bg-zinc-700 text-center text-lg md:text-xl lg:text-2xl dark:text-zinc-50 hover:underline hover:text-ow2-orange dark:hover:text-ow2-light-orange transition-colors"
+    class="self-center px-4 py-2 my-4 rounded bg-zinc-200 dark:bg-zinc-800 hover:bg-zinc-300 dark:hover:bg-zinc-700 text-center text-lg md:text-xl lg:text-2xl dark:text-zinc-50 hover:underline hover:text-ow2-orange dark:hover:text-ow2-light-orange transition-colors"
     in:fade={{duration: 500, delay: 1000, easing: quintInOut}}
     out:fade
     href="/">


### PR DESCRIPTION
This PR prevents the "Home" button on the error page of OW2Countdown from taking up the whole page width.
