### PR TITLE
feat: include event tags in RSS feed response

### DIFF
--- a/src/routes/feed.xml/+server.ts
+++ b/src/routes/feed.xml/+server.ts
@@ -46,8 +46,11 @@ export const GET: RequestHandler = async(fullRequest) => {
       baseItem["eventEndDate"] = formatRFC7231(parseISO(event.end_date));
       baseItem["eventEndTimestamp"] = Math.floor(parseISO(event.end_date).getTime() / 1000);
     }
+    const tags = event.tags
+      ? event.tags.split(",").map(tag => ({ tag: tag.trim() })).filter(c => c.tag)
+      : [];
     return {
-      item: baseItem
+      item: [baseItem, ...tags]
     };
   })
 


### PR DESCRIPTION
This pull request updates how event tags are processed and included in the feed response. Instead of returning only the base event item, the handler now parses the `tags` string, splits it into individual tags, and appends them to the response as separate objects.

The backend already supports everything required, only the response for the RSS feed was missing the tags.